### PR TITLE
Simplify landing page: drop Coming Soon, list features as text

### DIFF
--- a/backend/static/css/style.css
+++ b/backend/static/css/style.css
@@ -233,53 +233,29 @@ nav a:hover {
     font-size: 1.05rem;
 }
 
-.feature-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(290px, 1fr));
-    gap: 1.25rem;
+.feature-list {
+    list-style: none;
+    margin: 0 auto;
+    padding: 0;
+    max-width: 640px;
 }
 
-.feature-card {
-    background: var(--background);
-    padding: 1.75rem;
-    border-radius: 16px;
-    border: 1px solid var(--hairline);
-    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+.feature-list li {
+    margin: 0 0 1.5rem;
 }
 
-.feature-card:hover {
-    transform: translateY(-3px);
-    box-shadow: var(--shadow-md);
-    border-color: var(--accent-muted);
+.feature-list li:last-child {
+    margin-bottom: 0;
 }
 
-.feature-icon {
-    width: 44px;
-    height: 44px;
-    border-radius: 12px;
-    background: var(--accent-bg);
-    color: var(--brand);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.4rem;
-    margin-bottom: 1.1rem;
-    line-height: 1;
-}
-
-.feature-card h3 {
+.feature-list strong {
     color: var(--text-primary);
-    margin-bottom: 0.5rem;
-    font-size: 1.15rem;
-    font-weight: 600;
-    letter-spacing: -0.005em;
+    font-weight: 700;
 }
 
-.feature-card p {
+.feature-list span {
     color: var(--text-secondary);
-    font-size: 0.97rem;
     line-height: 1.6;
-    margin: 0;
 }
 
 /* CTA */

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -40,7 +40,6 @@
     <section class="hero">
         <div class="container">
             <img src="/static/images/app_icon.svg" alt="" class="hero-mark" aria-hidden="true">
-            <span class="badge">Coming soon</span>
             <h2>Your pocket reference for <em>jazz standards</em>, recordings, and the players who made them.</h2>
             <p>Explore the canonical works of the jazz tradition — every standard, every essential recording, every collaboration that mattered. Built for students, collectors, and listeners who want to go deeper.</p>
         </div>
@@ -52,43 +51,37 @@
             <h2>Everything you need to explore jazz</h2>
             <p>Carefully curated, cross-referenced, and always linkable to the recording you'll want to hear next.</p>
 
-            <div class="feature-grid">
-                <div class="feature-card">
-                    <div class="feature-icon">♪</div>
-                    <h3>Curated Standards</h3>
-                    <p>A comprehensive library of jazz standards with composer credits, structural notes, and historical context — researched and continuously refined.</p>
-                </div>
+            <ul class="feature-list">
+                <li>
+                    <strong>Curated Standards</strong>
+                    <span>A comprehensive library of jazz standards with composer credits, structural notes, and historical context — researched and continuously refined.</span>
+                </li>
 
-                <div class="feature-card">
-                    <div class="feature-icon">★</div>
-                    <h3>Canonical Recordings</h3>
-                    <p>The definitive versions of every standard. From Miles to Coltrane to Monk — explore the takes that shaped the music, with full personnel.</p>
-                </div>
+                <li>
+                    <strong>Canonical Recordings</strong>
+                    <span>The definitive versions of every standard. From Miles to Coltrane to Monk — explore the takes that shaped the music, with full personnel.</span>
+                </li>
 
-                <div class="feature-card">
-                    <div class="feature-icon">◐</div>
-                    <h3>Artist Profiles</h3>
-                    <p>Biographies, career highlights, and discographies for the players who defined the genre. Trace the connections between musicians and sessions.</p>
-                </div>
+                <li>
+                    <strong>Artist Profiles</strong>
+                    <span>Biographies, career highlights, and discographies for the players who defined the genre. Trace the connections between musicians and sessions.</span>
+                </li>
 
-                <div class="feature-card">
-                    <div class="feature-icon">◇</div>
-                    <h3>Rich Context</h3>
-                    <p>Every entry links out to Wikipedia, MusicBrainz, and other authoritative jazz sources. Go as deep into a song's history as you want.</p>
-                </div>
+                <li>
+                    <strong>Rich Context</strong>
+                    <span>Every entry links out to Wikipedia, MusicBrainz, and other authoritative jazz sources. Go as deep into a song's history as you want.</span>
+                </li>
 
-                <div class="feature-card">
-                    <div class="feature-icon">▦</div>
-                    <h3>Recording Details</h3>
-                    <p>Complete personnel lineups, recording dates, session labels, and source releases — know exactly who played what on every track.</p>
-                </div>
+                <li>
+                    <strong>Recording Details</strong>
+                    <span>Complete personnel lineups, recording dates, session labels, and source releases — know exactly who played what on every track.</span>
+                </li>
 
-                <div class="feature-card">
-                    <div class="feature-icon">▶</div>
-                    <h3>Listen Instantly</h3>
-                    <p>Direct links to Spotify and Apple Music open the recording right where you left the page. Hear what you're reading about.</p>
-                </div>
-            </div>
+                <li>
+                    <strong>Listen Instantly</strong>
+                    <span>Direct links to Spotify and Apple Music open the recording right where you left the page. Hear what you're reading about.</span>
+                </li>
+            </ul>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Remove the "Coming soon" badge from the hero section.
- Convert the "Everything you need to explore jazz" feature cards into a plain text list — no boxes, no icons — keeping each item's bold key message followed by supporting body text.

## Changes
- `backend/templates/index.html` — deleted the `.badge` span; replaced the `.feature-grid`/`.feature-card` markup (and icon glyphs) with a `<ul class="feature-list">`.
- `backend/static/css/style.css` — replaced the feature card/grid/icon styles with simpler `.feature-list` styling.

## Verification
Ran the Flask backend locally and confirmed in the browser preview that the badge is gone from the hero and the features render as a clean bold-lead-in text list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
